### PR TITLE
Use item_name instead of custom_name

### DIFF
--- a/data/turtle_tote/recipe/turtle_tote.json
+++ b/data/turtle_tote/recipe/turtle_tote.json
@@ -20,7 +20,7 @@
   "result": {
     "id": "minecraft:green_shulker_box",
     "components": {
-      "minecraft:custom_name": "{\"text\":\"Turtle Tote\",\"italic\":false}"
+      "minecraft:item_name": "Turtle Tote"
     }
   }
 }


### PR DESCRIPTION
Using custom_name in 1.21.8 is broken, but item_name works as intended and is better suited for the purpose as it can't be changed at an anvil.